### PR TITLE
Update k9s.spec

### DIFF
--- a/specs/k9s.spec
+++ b/specs/k9s.spec
@@ -9,7 +9,7 @@ License: Apache-2.0
 URL:     https://github.com/derailed/k9s
 Source0: https://github.com/derailed/k9s/archive/v%{version}.tar.gz
 
-%if 0%{?fedora} >= 42
+%if 0%{?fedora_version} >= 42
 BuildRequires: golang >= 1.24
 %else
 # Fedora < 42 does not have Go 1.24

--- a/specs/k9s.spec
+++ b/specs/k9s.spec
@@ -9,8 +9,12 @@ License: Apache-2.0
 URL:     https://github.com/derailed/k9s
 Source0: https://github.com/derailed/k9s/archive/v%{version}.tar.gz
 
+%if 0%{?fedora} >= 42
 BuildRequires: golang >= 1.24
-BuildRequires: git
+%else
+# Fedora < 42 does not have Go 1.24
+ExclusiveArch: do_not_build
+%endif
 
 %description
 K9s provides a terminal UI to interact with your Kubernetes clusters. The aim of this project

--- a/specs/k9s.spec
+++ b/specs/k9s.spec
@@ -9,8 +9,9 @@ License: Apache-2.0
 URL:     https://github.com/derailed/k9s
 Source0: https://github.com/derailed/k9s/archive/v%{version}.tar.gz
 
-%if 0%{?fedora_version} >= 42
+%if %{fedora} >= 42
 BuildRequires: golang >= 1.24
+BuildRequires: git
 %else
 # Fedora < 42 does not have Go 1.24
 ExclusiveArch: do_not_build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build requirements to only require Go 1.24 on Fedora 42 and above.
  - Disabled package builds on Fedora versions below 42.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->