### PR TITLE
Fix: specfiles to not use musl binaries

### DIFF
--- a/specs/atuin.spec
+++ b/specs/atuin.spec
@@ -7,7 +7,7 @@ Summary: Magical shell history
 
 License:    MIT
 URL:        https://github.com/atuinsh/atuin
-Source:     %{url}/releases/download/v%{version}/%{name}-x86_64-unknown-linux-musl.tar.gz
+Source:     %{url}/releases/download/v%{version}/%{name}-x86_64-unknown-linux-gnu.tar.gz
 Source1:    https://raw.githubusercontent.com/atuinsh/atuin/v%{version}/README.md
 Source2:    https://raw.githubusercontent.com/atuinsh/atuin/v%{version}/CHANGELOG.md
 
@@ -28,7 +28,7 @@ cp %{SOURCE2} .
 
 %install
 # Ensure the source binary is in the expected location
-install -p -D %{name}-x86_64-unknown-linux-musl/%{name} %{buildroot}%{_bindir}/%{name}
+install -p -D %{name}-x86_64-unknown-linux-gnu/%{name} %{buildroot}%{_bindir}/%{name}
 
 
 %files

--- a/specs/chezmoi.spec
+++ b/specs/chezmoi.spec
@@ -5,10 +5,10 @@ Version: 2.63.0
 Release: 1%{?dist}
 Summary: Manage your dotfiles across multiple diverse machines, securely.
 
-# https://github.com/twpayne/chezmoi/releases/download/v2.54.0/chezmoi_2.54.0_linux-musl_amd64.tar.gz
+# https://github.com/twpayne/chezmoi/releases/download/v2.54.0/chezmoi_2.54.0_linux-amd64.tar.gz
 License: MIT
 URL: https://github.com/twpayne/chezmoi
-Source: %{url}/releases/download/v%{version}/%{name}_%{version}_linux-musl_amd64.tar.gz
+Source: %{url}/releases/download/v%{version}/%{name}_%{version}_linux_amd64.tar.gz
 Source1: https://raw.githubusercontent.com/twpayne/chezmoi/v%{version}/README.md
 Source2: https://raw.githubusercontent.com/twpayne/chezmoi/v%{version}/LICENSE
 

--- a/specs/jj.spec
+++ b/specs/jj.spec
@@ -6,9 +6,9 @@ Release: 1%{?dist}
 Summary: A Git-compatible VCS that is both simple and powerful
 
 License: Apache v2.0
-# https://github.com/martinvonz/jj/releases/download/v0.23.0/jj-v0.23.0-x86_64-unknown-linux-musl.tar.gz
+# https://github.com/martinvonz/jj/releases/download/v0.23.0/jj-v0.23.0-x86_64-unknown-linux-gnu.tar.gz
 URL: https://github.com/martinvonz/jj
-Source: %{url}/releases/download/v%{version}/%{name}-v%{version}-x86_64-unknown-linux-musl.tar.gz
+Source: %{url}/releases/download/v%{version}/%{name}-v%{version}-x86_64-unknown-linux-gnu.tar.gz
 Source1: https://raw.githubusercontent.com/martinvonz/jj/v%{version}/README.md
 Source2: https://raw.githubusercontent.com/martinvonz/jj/v%{version}/LICENSE
 

--- a/specs/lazyjj.spec
+++ b/specs/lazyjj.spec
@@ -6,9 +6,9 @@ Release: 1%{?dist}
 Summary: TUI for Jujutsu/jj
 
 License: Apache-2.0
-# https://github.com/Cretezy/lazyjj/releases/download/v0.4.2/lazyjj-v0.4.2-x86_64-unknown-linux-musl.tar.gz
+# https://github.com/Cretezy/lazyjj/releases/download/v0.4.2/lazyjj-v0.4.2-x86_64-unknown-linux-gnu.tar.gz
 URL: https://github.com/Cretezy/lazyjj
-Source: %{url}/releases/download/v%{version}/%{name}-v%{version}-x86_64-unknown-linux-musl.tar.gz
+Source: %{url}/releases/download/v%{version}/%{name}-v%{version}-x86_64-unknown-linux-gnu.tar.gz
 Source1: https://raw.githubusercontent.com/Cretezy/lazyjj/v%{version}/README.md
 Source2: https://raw.githubusercontent.com/Cretezy/lazyjj/v%{version}/LICENSE
 

--- a/specs/mise.spec
+++ b/specs/mise.spec
@@ -7,7 +7,7 @@ Summary: dev tools, env vars, task runner
 
 License:    MIT
 URL:        https://github.com/jdx/mise
-Source:     %{url}/releases/download/v%{version}/%{name}-v%{version}-linux-x64-musl.tar.gz
+Source:     %{url}/releases/download/v%{version}/%{name}-v%{version}-linux-x64.tar.gz
 Source1:    https://raw.githubusercontent.com/jdx/mise/v%{version}/README.md
 Source2:    https://raw.githubusercontent.com/jdx/mise/v%{version}/completions/mise.bash
 Source3:    https://raw.githubusercontent.com/jdx/mise/v%{version}/completions/mise.fish

--- a/specs/topgrade.spec
+++ b/specs/topgrade.spec
@@ -6,9 +6,9 @@ Release: 1%{?dist}
 Summary: Upgrade all the things
 
 License: GPL-3.0
-# https://github.com/topgrade-rs/topgrade/releases/download/v16.0.1/topgrade-v16.0.1-x86_64-unknown-linux-musl.tar.gz
+# https://github.com/topgrade-rs/topgrade/releases/download/v16.0.1/topgrade-v16.0.1-x86_64-unknown-linux-gnu.tar.gz
 URL:     https://github.com/topgrade-rs/topgrade
-Source:  %{url}/releases/download/v%{version}/%{name}-v%{version}-x86_64-unknown-linux-musl.tar.gz
+Source:  %{url}/releases/download/v%{version}/%{name}-v%{version}-x86_64-unknown-linux-gnu.tar.gz
 Source1: https://raw.githubusercontent.com/topgrade-rs/topgrade/v%{version}/README.md
 Source2: https://raw.githubusercontent.com/topgrade-rs/topgrade/v%{version}/LICENSE
 

--- a/specs/usage.spec
+++ b/specs/usage.spec
@@ -7,7 +7,7 @@ Summary: A specification for CLIs
 
 License:    MIT
 URL:        https://github.com/jdx/usage
-Source:     %{url}/releases/download/v%{version}/%{name}-x86_64-unknown-linux-musl.tar.gz
+Source:     %{url}/releases/download/v%{version}/%{name}-x86_64-unknown-linux-gnu.tar.gz
 Source1:    https://raw.githubusercontent.com/jdx/usage/v%{version}/README.md
 
 %description

--- a/specs/uv.spec
+++ b/specs/uv.spec
@@ -7,7 +7,7 @@ Summary: An extremely fast Python package and project manager, written in Rust.
 
 License:    MIT
 URL:        https://github.com/astral-sh/uv
-Source:     %{url}/releases/download/%{version}/%{name}-x86_64-unknown-linux-musl.tar.gz
+Source:     %{url}/releases/download/%{version}/%{name}-x86_64-unknown-linux-gnu.tar.gz
 Source1:    https://raw.githubusercontent.com/astral-sh/uv/%{version}/README.md
 
 %description
@@ -34,7 +34,7 @@ cp %{SOURCE1} CONFIGURATION.md
 
 %install
 # Ensure the source binary is in the expected location
-install -p -D %{name}-x86_64-unknown-linux-musl/%{name} %{buildroot}%{_bindir}/%{name}
+install -p -D %{name}-x86_64-unknown-linux-gnu/%{name} %{buildroot}%{_bindir}/%{name}
 
 %files
 %doc CONFIGURATION.md

--- a/specs/zellij.spec
+++ b/specs/zellij.spec
@@ -7,7 +7,7 @@ Summary: A terminal workspace with batteries included
 
 License:    MIT
 URL:        https://github.com/zellij-org/zellij
-Source:     %{url}/releases/download/v%{version}/%{name}-x86_64-unknown-linux-musl.tar.gz
+Source:     %{url}/releases/download/v%{version}/%{name}-x86_64-unknown-linux-gnu.tar.gz
 Source1:    https://raw.githubusercontent.com/zellij-org/zellij/v%{version}/docs/MANPAGE.md
 
 BuildRequires: pandoc

--- a/specs/zenith.spec
+++ b/specs/zenith.spec
@@ -7,9 +7,9 @@ Release: 1%{?dist}
 Summary: Sort of like top or htop but with zoom-able charts, CPU, GPU, network, and disk usage
 
 License: MIT
-# https://github.com/bvaisvil/zenith/releases/download/0.14.1/zenith.x86_64-unknown-linux-musl.tgz
+# https://github.com/bvaisvil/zenith/releases/download/0.14.1/zenith.x86_64-unknown-linux-gnu.tgz
 URL:     https://github.com/bvaisvil/zenith
-Source:  %{url}/releases/download/%{version}/%{name}.x86_64-unknown-linux-musl.tgz
+Source:  %{url}/releases/download/%{version}/%{name}.x86_64-unknown-linux-gnu.tgz
 Source1: %{raw_ghuc}/%{version}/README.md
 Source2: %{raw_ghuc}/%{version}/LICENSE
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package sources across multiple packages to use GNU-based Linux binaries instead of musl-based binaries. This change affects the download URLs and installation paths but does not impact package functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->